### PR TITLE
Remove unnecessary reflection

### DIFF
--- a/CarJack.Plugin/Plugin.cs
+++ b/CarJack.Plugin/Plugin.cs
@@ -31,7 +31,6 @@ namespace CarJack.Plugin
 #endif
                 CarDatabase.Initialize();
                 CarJackApp.Initialize(directory);
-                LoadCompatibilityPlugins();
                 var playerData = new PlayerData();
                 playerData.LoadOrCreate();
                 Logger.LogInfo($"Loaded {PluginInfo.PLUGIN_NAME} {PluginInfo.PLUGIN_VERSION}!");
@@ -39,50 +38,6 @@ namespace CarJack.Plugin
             catch(Exception e)
             {
                 Logger.LogError($"Failed to load {PluginInfo.PLUGIN_NAME} {PluginInfo.PLUGIN_VERSION}!{Environment.NewLine}{e}");
-            }
-        }
-
-        private void LoadCompatibilityPlugins()
-        {
-            if (Chainloader.PluginInfos.ContainsKey("SlopCrew.Plugin"))
-            {
-                Logger.LogInfo("Loading CarJack SlopCrew Plugin!");
-                try
-                {
-                    var assemblyLocation = Path.Combine(Path.GetDirectoryName(Info.Location), "CarJack.SlopCrew.dll");
-                    LoadPlugin(assemblyLocation);
-                }
-                catch (Exception e)
-                {
-                    Logger.LogError($"Failed to load CarJack SlopCrew Plugin!{Environment.NewLine}{e}");
-                }
-            }
-
-            if (Chainloader.PluginInfos.ContainsKey("BombRushCamera"))
-            {
-                Logger.LogInfo("Loading CarJack BombRushCamera Plugin!");
-                try
-                {
-                    var assemblyLocation = Path.Combine(Path.GetDirectoryName(Info.Location), "CarJack.BombRushCamera.dll");
-                    LoadPlugin(assemblyLocation);
-                }
-                catch (Exception e)
-                {
-                    Logger.LogError($"Failed to load CarJack BombRushCamera Plugin!{Environment.NewLine}{e}");
-                }
-            }
-        }
-
-        private void LoadPlugin(string assemblyPath)
-        {
-            var assembly = Assembly.LoadFrom(assemblyPath);
-            var typesInAssembly = assembly.GetTypes();
-            foreach(var type in typesInAssembly)
-            {
-                if (type.GetCustomAttribute<CarJackPluginAttribute>() != null)
-                {
-                    var instance = Activator.CreateInstance(type);
-                }
             }
         }
     }


### PR DESCRIPTION
These plugins are implictly loaded by the bepinex softdependency.

It also is the thing that keeps tripping the malware filter on your plugin.